### PR TITLE
feat(blinking-contrib): implement right-aligned yearly contribution grids

### DIFF
--- a/packages/blinking-contrib/src/index.ts
+++ b/packages/blinking-contrib/src/index.ts
@@ -113,8 +113,8 @@ export function generateBlinkingSVG(
       const week = grid.weeks[weekIdx];
       for (let dayIdx = 0; dayIdx < week.length; dayIdx++) {
         const day = week[dayIdx];
-        // All years are now aligned from Jan 1, no offset needed
-        const x = weekIdx * (cellSize + cellGap);
+        // Apply weekOffset for right-alignment (all years' last week aligns)
+        const x = (weekIdx + yearContrib.weekOffset) * (cellSize + cellGap);
         const y = dayIdx * (cellSize + cellGap);
 
         // Calculate color level based on contribution count


### PR DESCRIPTION
- Remove outdated comments and adjust logic to generate grids from year start to current date
- For current year, grid ends on today's date; for past years, ends on Dec 31
- Update week boundary calculation to align with dynamic end date
- Introduce weekOffset calculation to right-align all years based on the longest year
- Adjust SVG rendering to apply weekOffset for visual alignment of year ends
- Improve logging to reflect right-alignment logic and offset values

Signed-off-by: diverger <diverger@live.cn>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Multi-year contribution grids are now right-aligned by the last week, making year-to-year comparisons easier.
  - The current year’s grid dynamically ends at today, while past years extend to Dec 31 for accurate coverage.
- Style
  - Updated horizontal positioning of day cells to reflect the new right-aligned layout, delivering a cleaner and more consistent visual presentation across years.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->