### PR TITLE
fix(docker): add entrypoint configuration to breathing and snake Dockerfiles

### DIFF
--- a/Dockerfile.breathing
+++ b/Dockerfile.breathing
@@ -29,3 +29,6 @@ WORKDIR /app
 
 # Copy only the built artifact from builder
 COPY --from=builder /app/dist ./dist
+
+# Set entry point
+ENTRYPOINT ["bun", "/app/dist/index.js"]

--- a/Dockerfile.snake
+++ b/Dockerfile.snake
@@ -30,3 +30,6 @@ WORKDIR /app
 
 # Copy only the built artifact from builder
 COPY --from=builder /app/dist ./dist
+
+# Set entry point
+ENTRYPOINT ["bun", "/app/dist/index.js"]


### PR DESCRIPTION
Set the entrypoint to execute the built artifact using bun runtime. This ensures the containers start correctly with the proper command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated containerized application startup configuration to ensure the application executes properly when deployed in Docker environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->